### PR TITLE
Enable searchable inside users list screen to find specific users

### DIFF
--- a/GhUserCollection/Sources/Github/GithubModels.swift
+++ b/GhUserCollection/Sources/Github/GithubModels.swift
@@ -28,6 +28,8 @@ struct GithubUser: Decodable, Equatable {
  */
 struct GithubUserInfo: Decodable {
     let id: Int64
+    let login: String
+    let avatarUrl: URL
     let name: String
     let followers: Int
     let following: Int

--- a/GhUserCollectionTests/Github/GithubModelTests.swift
+++ b/GhUserCollectionTests/Github/GithubModelTests.swift
@@ -48,7 +48,9 @@ final class GithubModelsTests: XCTestCase {
     func test_decode_userInfo() throws {
         let jsonString = """
         {
+          "login": "octocat",
           "id": 1,
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
           "name": "monalisa octocat",
           "followers": 20,
           "following": 0
@@ -57,6 +59,8 @@ final class GithubModelsTests: XCTestCase {
         let userInfo = try decoder.decode(GithubUserInfo.self, from: response(jsonString: jsonString))
         
         XCTAssertEqual(userInfo.id, 1)
+        XCTAssertEqual(userInfo.login, "octocat")
+        XCTAssertEqual(userInfo.avatarUrl, URL(string: "https://github.com/images/error/octocat_happy.gif"))
         XCTAssertEqual(userInfo.name, "monalisa octocat")
         XCTAssertEqual(userInfo.followers, 20)
         XCTAssertEqual(userInfo.following, 0)


### PR DESCRIPTION
The searchable property I think is normally used for filtering items, but in this infinite scrolling list's case, it makes more sense to actually do a network call since the user may not have been loaded yet. Introduced a debounce to limit network calls and added necessary elements whenever the user taps the search bar

| | |
| --- | --- |
| <img width="556" alt="Screenshot 2024-09-06 at 18 42 27" src="https://github.com/user-attachments/assets/6b25a7f5-4dc1-4520-9a4a-4c9be521c58a"> | <img width="540" alt="Screenshot 2024-09-06 at 18 42 36" src="https://github.com/user-attachments/assets/0897402d-0974-45ce-a109-5e2820660814"> |
| <img width="579" alt="Screenshot 2024-09-06 at 18 42 45" src="https://github.com/user-attachments/assets/11c0d7c6-dbf5-45b2-b2ce-d0a2b3578957"> | <img width="501" alt="Screenshot 2024-09-06 at 18 42 53" src="https://github.com/user-attachments/assets/f39c4fae-5d4e-40ed-92c9-48cfd163c70a"> |
