### PR TITLE
Implement user profile screen

### DIFF
--- a/GhUserCollection.xcodeproj/project.pbxproj
+++ b/GhUserCollection.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		BF1DA8342C8AF9AD00F32F34 /* DependencyGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1DA8332C8AF9AD00F32F34 /* DependencyGraph.swift */; };
 		BF1DA8362C8AF9B700F32F34 /* ApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1DA8352C8AF9B700F32F34 /* ApiClient.swift */; };
 		BF1DA8392C8AFBFD00F32F34 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = BF1DA8382C8AFBFD00F32F34 /* Kingfisher */; };
+		BF1DA83B2C8B099400F32F34 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1DA83A2C8B099400F32F34 /* UserProfileView.swift */; };
+		BF1DA83D2C8B09A100F32F34 /* UserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1DA83C2C8B09A100F32F34 /* UserProfileViewModel.swift */; };
 		BF48F46D2C887FCB00F554E8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48F46C2C887FCB00F554E8 /* ContentView.swift */; };
 		BF48F4752C88930C00F554E8 /* ArkanaKeys in Frameworks */ = {isa = PBXBuildFile; productRef = BF48F4742C88930C00F554E8 /* ArkanaKeys */; };
 		BFA4BB992C887C14006B123A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BFA4BB912C887C13006B123A /* Preview Assets.xcassets */; };
@@ -52,6 +54,8 @@
 		BF1DA8302C8AF97500F32F34 /* UsersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersListViewModel.swift; sourceTree = "<group>"; };
 		BF1DA8332C8AF9AD00F32F34 /* DependencyGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyGraph.swift; sourceTree = "<group>"; };
 		BF1DA8352C8AF9B700F32F34 /* ApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiClient.swift; sourceTree = "<group>"; };
+		BF1DA83A2C8B099400F32F34 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
+		BF1DA83C2C8B09A100F32F34 /* UserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModel.swift; sourceTree = "<group>"; };
 		BF48F46C2C887FCB00F554E8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BF48F4712C888D9B00F554E8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BFA4BB912C887C13006B123A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -149,6 +153,8 @@
 				BF48F46C2C887FCB00F554E8 /* ContentView.swift */,
 				BF1DA82E2C8AF96600F32F34 /* UsersListView.swift */,
 				BF1DA8302C8AF97500F32F34 /* UsersListViewModel.swift */,
+				BF1DA83A2C8B099400F32F34 /* UserProfileView.swift */,
+				BF1DA83C2C8B09A100F32F34 /* UserProfileViewModel.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -353,11 +359,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF0FB7F92C89FFB300A4F87C /* GithubModels.swift in Sources */,
+				BF1DA83B2C8B099400F32F34 /* UserProfileView.swift in Sources */,
 				BF1DA8312C8AF97500F32F34 /* UsersListViewModel.swift in Sources */,
 				BF1DA8342C8AF9AD00F32F34 /* DependencyGraph.swift in Sources */,
 				BF1DA8362C8AF9B700F32F34 /* ApiClient.swift in Sources */,
 				BFCB32DE2C88799C00245FF2 /* GhUserCollectionApp.swift in Sources */,
 				BF1DA82F2C8AF96600F32F34 /* UsersListView.swift in Sources */,
+				BF1DA83D2C8B09A100F32F34 /* UserProfileViewModel.swift in Sources */,
 				BF48F46D2C887FCB00F554E8 /* ContentView.swift in Sources */,
 				BF0FB7FB2C89FFC100A4F87C /* GithubClient.swift in Sources */,
 			);

--- a/GhUserCollection/Sources/UI/ContentView.swift
+++ b/GhUserCollection/Sources/UI/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
         NavigationStack {
             UsersListView(viewModel: viewModel)
         }
+        .environmentObject(dependencyGraph)
     }
 }
 

--- a/GhUserCollection/Sources/UI/UserProfileView.swift
+++ b/GhUserCollection/Sources/UI/UserProfileView.swift
@@ -1,0 +1,269 @@
+//
+//  UserProfileView.swift
+//  GhUserCollection
+//
+//  Created by Paulus Armada on 2024/09/06.
+//
+
+import Kingfisher
+import SwiftUI
+
+struct UserProfileView: View {
+    @ObservedObject var viewModel: UserProfileViewModel
+    @Environment(\.dismiss) var dismiss
+    @State var isAlertPresented = false
+    
+    var body: some View {
+        List {
+            Section {
+                switch viewModel.repositories {
+                
+                // Display the list of repositories if not empty
+                case .some(let repositories) where !repositories.isEmpty:
+                    ForEach(repositories, id: \.id) { repository in
+                        // TODO: Show repository view
+                        NavigationLink(destination: EmptyView()) {
+                            repositoryRow(repository)
+                        }
+                    }
+                    
+                // Show a note if the user does not have any repository
+                case .some:
+                    Text("No repositories found")
+                        .italic()
+                        .font(.footnote)
+                        .foregroundStyle(Color.gray)
+                        .frame(maxWidth: .infinity)
+                        .listRowSeparator(.hidden)
+                    
+                // Show a progress view when it is still pulling data
+                case .none:
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            } header: {
+                // Make the info section a header so we can make it freeze on top
+                HStack(alignment: .center, spacing: 16) {
+                    //  ・Avatar image
+                    KFImage.url(viewModel.user.avatarUrl)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 120, height: 120)
+                    
+                        // Make a nice circle with a frame
+                        .clipShape(Circle())
+                        .overlay(content: {
+                            Circle()
+                                .stroke(Color.gray, lineWidth: 1)
+                        })
+                    
+                    if let userInfo = viewModel.userInfo {
+                        VStack(alignment: .leading) {
+                            // ・Full name
+                            Text(userInfo.name)
+                                .font(.title2)
+                                .foregroundStyle(Color.primary)
+                                .padding(.bottom, 8)
+                            
+                            // ・Number of followers
+                            Text("Followers: \(userInfo.followers)")
+                                .font(.footnote)
+                                .foregroundStyle(Color.primary)
+                            
+                            // ・Number of followings
+                            Text("Following: \(userInfo.following)")
+                                .font(.footnote)
+                                .foregroundStyle(Color.primary)
+                        }
+                    } else {
+                        // Show a progress view when it is still pulling data
+                        ProgressView()
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                }
+                .padding([.top, .bottom], 16)
+            }
+        }
+        .listStyle(.inset)
+        .onAppear {
+            Task {
+                do {
+                    try await viewModel.fetch()
+                } catch {
+                    isAlertPresented = true
+                }
+            }
+        }
+        
+        // ・Username
+        .navigationTitle(viewModel.user.login)
+        
+        // Show an alert that dismiss the screen when fetching fails
+        .alert(isPresented: $isAlertPresented) {
+            Alert(
+                title: Text("Error"),
+                message: Text("An unknown error occured"),
+                dismissButton: .default(Text("OK"), action: {
+                    dismiss()
+                })
+            )
+        }
+    }
+    
+    @ViewBuilder
+    private func repositoryRow(_ repository: GithubRepository) -> some View {
+        VStack(alignment: .leading) {
+            // ・Repository name
+            Text(repository.name)
+                .bold()
+                .underline()
+                .font(.headline)
+                .foregroundStyle(Color.blue)
+            
+            // ・Description (Displayed only when available)
+            if let description = repository.description, !description.isEmpty {
+                Text(description)
+                    .font(.subheadline)
+                    .padding(.top, 2)
+            }
+            
+            HStack(spacing: 8) {
+                // ・Programming language used (Displayed only when available)
+                if let language = repository.language {
+                    Text(language)
+                        .font(.footnote)
+                }
+                
+                // ・Number of stars (Displayed only when not 0)
+                if repository.stargazersCount > 0 {
+                    Text("⭐ \(repository.stargazersCount)")
+                        .font(.footnote)
+                }
+            }
+            .padding(.top, 8)
+        }
+    }
+}
+
+struct UserProfileView_Previews: PreviewProvider {
+    
+    class MockApiClient: ApiClient {
+        enum MockError: Error {
+            case unknown
+        }
+        
+        let hasRepos: Bool
+        let failOnFetch: Bool
+        
+        init(hasRepos: Bool, failOnFetch: Bool) {
+            self.hasRepos = hasRepos
+            self.failOnFetch = failOnFetch
+        }
+        
+        func getUsers(since: Int64, perPage: Int) async throws -> [GithubUser] {
+            throw MockError.unknown
+        }
+        
+        func getUserInfo(login: String) async throws -> GithubUserInfo {
+            guard !failOnFetch else {
+                throw MockError.unknown
+            }
+            
+            return GithubUserInfo(
+                id: Int64(0),
+                login: "test",
+                avatarUrl: URL(string: "https://httpbin.org/image/png")!,
+                name: "Github User",
+                followers: 10,
+                following: 10
+            )
+        }
+        
+        func getRepositories(login: String) async throws -> [GithubRepository] {
+            guard !failOnFetch else {
+                throw MockError.unknown
+            }
+            
+            return hasRepos ?
+                [
+                    GithubRepository(
+                        id: 0,
+                        name: "nodescription",
+                        description: nil,
+                        fork: false,
+                        language: nil,
+                        stargazersCount: 0,
+                        htmlUrl: URL(string: "https://www.google.com")!
+                    ),
+                    GithubRepository(
+                        id: 1,
+                        name: "repository1",
+                        description: "language:nil stars:40",
+                        fork: false,
+                        language: nil,
+                        stargazersCount: 40,
+                        htmlUrl: URL(string: "https://www.google.com")!
+                    ),
+                    GithubRepository(
+                        id: 2,
+                        name: "repository2",
+                        description: "language:Swift stars:0",
+                        fork: false,
+                        language: "Swift",
+                        stargazersCount: 0,
+                        htmlUrl: URL(string: "https://www.google.com")!
+                    ),
+                    GithubRepository(
+                        id: 3,
+                        name: "repository3",
+                        description: "language:Swift stars:40",
+                        fork: false,
+                        language: "Swift",
+                        stargazersCount: 40,
+                        htmlUrl: URL(string: "https://www.google.com")!
+                    ),
+                    GithubRepository(
+                        id: 4,
+                        name: "repository4 (FORK)",
+                        description: "language:Swift stars:40",
+                        fork: true,
+                        language: "Swift",
+                        stargazersCount: 40,
+                        htmlUrl: URL(string: "https://www.google.com")!
+                    )
+                ] : []
+        }
+    }
+    
+    @ViewBuilder
+    static func create(
+        hasRepos: Bool,
+        failOnFetch: Bool,
+        colorScheme: ColorScheme
+    ) -> some View {
+        let user = GithubUser(
+            id: 0,
+            login: "githubuser",
+            avatarUrl: URL(string: "https://httpbin.org/image/png")!
+        )
+        
+        let viewModel = UserProfileViewModel(
+            user: user,
+            apiClient: MockApiClient(hasRepos: hasRepos, failOnFetch: failOnFetch)
+        )
+        NavigationStack {
+            UserProfileView(viewModel: viewModel)
+        }
+        .preferredColorScheme(colorScheme)
+        .previewDisplayName("hasRepos: \(hasRepos);failOnFetch:\(failOnFetch);colorScheme:\(colorScheme)")
+    }
+    
+    static var previews: some View {
+        create(hasRepos: false, failOnFetch: false, colorScheme: .light)
+        create(hasRepos: false, failOnFetch: false, colorScheme: .dark)
+        create(hasRepos: true, failOnFetch: false, colorScheme: .light)
+        create(hasRepos: true, failOnFetch: false, colorScheme: .dark)
+        create(hasRepos: true, failOnFetch: true, colorScheme: .light)
+        create(hasRepos: true, failOnFetch: true, colorScheme: .dark)
+    }
+}

--- a/GhUserCollection/Sources/UI/UserProfileViewModel.swift
+++ b/GhUserCollection/Sources/UI/UserProfileViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  UserProfileViewModel.swift
+//  GhUserCollection
+//
+//  Created by Paulus Armada on 2024/09/06.
+//
+
+import Kingfisher
+import SwiftUI
+
+@MainActor
+class UserProfileViewModel: ObservableObject {
+    let user: GithubUser
+    private let apiClient: ApiClient
+    
+    @Published var userInfo: GithubUserInfo? = nil
+    @Published var repositories: [GithubRepository]? = nil
+    
+    init(user: GithubUser, apiClient: ApiClient) {
+        self.user = user
+        self.apiClient = apiClient
+    }
+    
+    // Should be performed on demand so that it does not fetch data
+    // even as the view model is created
+    func fetch() async throws {
+        _ = await [
+            try self.fetchUserInfo(login: user.login),
+            try self.fetchRepositories(login: user.login)
+        ]
+    }
+    
+    private func fetchUserInfo(login: String) async throws {
+        userInfo = try await apiClient.getUserInfo(login: login)
+    }
+    
+    private func fetchRepositories(login: String) async throws {
+        let repositories = try await apiClient.getRepositories(login: login)
+        
+        // Filter out the forked repositories
+        self.repositories = repositories.filter { !$0.fork }
+    }
+}

--- a/GhUserCollection/Sources/UI/UsersListView.swift
+++ b/GhUserCollection/Sources/UI/UsersListView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct UsersListView: View {
     @ObservedObject var viewModel: UsersListViewModel
+    @EnvironmentObject var dependencyGraph: DependencyGraph
     
     @State var searchText = ""
     @State var isSearchPresented = false
@@ -83,8 +84,8 @@ struct UsersListView: View {
     
     @ViewBuilder
     func userRow(_ user: GithubUser) -> some View {
-        // TODO: Change destination
-        NavigationLink(destination: EmptyView()) {
+        let viewModel = UserProfileViewModel(user: user, apiClient: dependencyGraph.apiClient)
+        NavigationLink(destination: UserProfileView(viewModel: viewModel)) {
             HStack(alignment: .center, spacing: 12) {
                 // ・User's avatar image
                 KFImage.url(user.avatarUrl)
@@ -168,14 +169,14 @@ struct UsersListView_Previews: PreviewProvider {
     
     @ViewBuilder
     static func create(failOnFirst: Bool, colorScheme: ColorScheme) -> some View {
+        let apiClient = MockApiClient(failOnFirst: failOnFirst)
         NavigationStack {
             UsersListView(
-                viewModel: UsersListViewModel(
-                    apiClient: MockApiClient(failOnFirst: failOnFirst)
-                )
+                viewModel: UsersListViewModel(apiClient: apiClient)
             )
         }
         .preferredColorScheme(colorScheme)
+        .environmentObject(DependencyGraph(apiClient: apiClient))
         .previewDisplayName("failOnFirst:\(failOnFirst); colorScheme:\(colorScheme)")
     }
     


### PR DESCRIPTION
Add the action when tapping a user from the users list screen and display this new user profile screen. The user info (followers/following count and name) and the repositories are fetched separately in parallel when the screen is displayed.

| | |
| - | - |
| <img width="559" alt="Screenshot 2024-09-06 at 21 00 04" src="https://github.com/user-attachments/assets/9681810f-d0b6-4eb7-b43a-0a23f460eed8"> | <img width="912" alt="Screenshot 2024-09-06 at 20 58 59" src="https://github.com/user-attachments/assets/03eefcd5-76b6-4b1b-8bc7-39ab8e3875bd"> |
| <img width="910" alt="Screenshot 2024-09-06 at 20 59 12" src="https://github.com/user-attachments/assets/cb229363-11ec-4544-9b90-336137ec4d7f"> | |
